### PR TITLE
refactor(agent): split commit guidelines into focused files

### DIFF
--- a/.agent/guidelines/README.md
+++ b/.agent/guidelines/README.md
@@ -12,7 +12,8 @@ Guidelines define **what to do and why** - the standards and conventions that ma
 
 - `branch-naming.md` - Branch naming conventions for different types of changes
 - `branch-strategy.md` - When and how to create new branches
-- `commit.md` - Git commit conventions using Conventional Commits format
+- `commit-message.md` - Git commit message conventions using Conventional Commits format
+- `commit-strategy.md` - Commit granularity and dependency management
 
 ### Development Standards
 
@@ -25,7 +26,7 @@ Guidelines define **what to do and why** - the standards and conventions that ma
 
 - **ALWAYS** read `project.md` at the start of a session
 - **BEFORE** creating branches - read `branch-naming.md` and `branch-strategy.md`
-- **BEFORE** making commits - read `commit.md`
+- **BEFORE** making commits - read `commit-message.md` and `commit-strategy.md`
 - **WHEN** adding logging - read `logging.md`
 - **WHEN** installing tools - read `tool-management.md`
 - **WHEN** working with moon tasks - read `monorepo-management.md`

--- a/.agent/guidelines/commit-message.md
+++ b/.agent/guidelines/commit-message.md
@@ -1,24 +1,8 @@
-# Git Conventions for AI Agents
+# Commit Message Conventions
 
-This document defines the conventions and rules for git commits. For step-by-step commit workflows, see `workflows/commit.md`.
-
-## Commit Granularity
-
-- Keep commits atomic: one logical change per commit
-- Related changes should be committed together
-- Unrelated changes should be in separate commits
-- Each commit should represent a complete, working state
-- Each commit should pass all tests and checks (lint, format, typecheck, etc.)
-
-## Commit Dependencies
-
-- Consider logical dependencies between commits
-- Infrastructure changes before features that use them
-- Tool installations before tool configurations
-- Configurations before code that depends on them
-- Bug fixes that enable tests before the tests themselves
-
-For specific ordering strategies and examples, see `workflows/commit.md`
+This document defines the conventions and rules for git commit messages.
+For step-by-step commit workflows, see `workflows/commit.md`.
+For commit granularity and strategy, see `commit-strategy.md`.
 
 ## Commit Messages
 
@@ -26,13 +10,13 @@ AI agents must follow the Conventional Commits specification:
 
 ### Format
 
-````text
+```text
 <type>[optional scope][!]: <description>
 
 [optional body]
 
 [optional footer(s)]
-```text
+```
 
 ### Types
 
@@ -76,5 +60,4 @@ feat(lang): add Japanese localization
 refactor(auth)!: replace JWT with session-based auth
 
 Refs: #456
-```text
-````
+```

--- a/.agent/guidelines/commit-strategy.md
+++ b/.agent/guidelines/commit-strategy.md
@@ -1,0 +1,23 @@
+# Commit Strategy and Granularity
+
+This document defines the strategy for organizing and structuring commits.
+For commit message format, see `commit-message.md`.
+For step-by-step commit workflows, see `workflows/commit.md`.
+
+## Commit Granularity
+
+- Keep commits atomic: one logical change per commit
+- Related changes should be committed together
+- Unrelated changes should be in separate commits
+- Each commit should represent a complete, working state
+- Each commit should pass all tests and checks (lint, format, typecheck, etc.)
+
+## Commit Dependencies
+
+- Consider logical dependencies between commits
+- Infrastructure changes before features that use them
+- Tool installations before tool configurations
+- Configurations before code that depends on them
+- Bug fixes that enable tests before the tests themselves
+
+For specific ordering strategies and examples, see `workflows/commit.md`

--- a/.agent/workflows/commit.md
+++ b/.agent/workflows/commit.md
@@ -21,7 +21,8 @@ This document describes the step-by-step process for making commits.
 2. **Plan commit(s) and branch name:**
 
    **First, check commit message guidelines:**
-   - See `guidelines/commit.md` for format and conventions
+   - See `guidelines/commit-message.md` for format and conventions
+   - See `guidelines/commit-strategy.md` for granularity and dependencies
    - Follow Conventional Commits format: `<type>(<scope>): <subject>`
 
    ```text
@@ -185,5 +186,6 @@ When making multiple commits, follow this order:
 
 ## References
 
-- See `guidelines/commit.md` for commit message format and conventions
+- See `guidelines/commit-message.md` for commit message format and conventions
+- See `guidelines/commit-strategy.md` for commit granularity and dependency management
 - See `workflows/tdd.md` for test-driven development commit patterns


### PR DESCRIPTION
## Summary
- Split `.agent/guidelines/commit.md` into two more focused files:
  - `commit-message.md`: Commit message format and conventions
  - `commit-strategy.md`: Commit granularity and dependency management
- Updated all references in related documentation files

## Why
The original `commit.md` file contained two distinct concerns that are better separated:
1. How to format commit messages (syntax and conventions)
2. How to organize commits (strategy and dependencies)

Splitting these improves documentation clarity and makes it easier to reference specific guidelines.

## Testing
- ✅ All moon checks pass (`moon run :check`)
- ✅ Documentation references updated in:
  - `.agent/guidelines/README.md`
  - `.agent/workflows/commit.md`