### PR TITLE
fix(moon): improve cache invalidation for .agent and .claude directories

### DIFF
--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -10,9 +10,11 @@ tasks:
 
   # Linting tasks (markdownlint)
   lint:
-    command: 'markdownlint-cli2 "**/*.md"'
+    command: 'markdownlint-cli2'
+    args: '"**/*.md"'
   lint-fix:
-    command: 'markdownlint-cli2 --fix "**/*.md"'
+    command: 'markdownlint-cli2'
+    args: ['--fix', '"**/*.md"']
 
   # Testing (default noop, override in language-specific tasks)
   test:

--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -10,11 +10,11 @@ tasks:
 
   # Linting tasks (markdownlint)
   lint:
-    command: 'markdownlint-cli2'
+    command: "markdownlint-cli2"
     args: '"**/*.md"'
   lint-fix:
-    command: 'markdownlint-cli2'
-    args: ['--fix', '"**/*.md"']
+    command: "markdownlint-cli2"
+    args: ["--fix", '"**/*.md"']
 
   # Testing (default noop, override in language-specific tasks)
   test:

--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -5,22 +5,14 @@ tasks:
   # Formatting tasks (dprint)
   format:
     command: "dprint fmt"
-    options:
-      runFromWorkspaceRoot: true
   format-check:
     command: "dprint check"
-    options:
-      runFromWorkspaceRoot: true
 
   # Linting tasks (markdownlint)
   lint:
     command: 'markdownlint-cli2 "**/*.md"'
-    options:
-      runFromWorkspaceRoot: true
   lint-fix:
     command: 'markdownlint-cli2 --fix "**/*.md"'
-    options:
-      runFromWorkspaceRoot: true
 
   # Testing (default noop, override in language-specific tasks)
   test:

--- a/docs/moon.yml
+++ b/docs/moon.yml
@@ -4,4 +4,8 @@ project:
   name: "docs"
   description: "Project documentation (PRDs, design docs, ADRs)"
 
-tasks: {}
+tasks:
+  lint:
+    args: ["--config", "../.markdownlint.yaml"]
+    options:
+      mergeArgs: "prepend"

--- a/moon.yml
+++ b/moon.yml
@@ -16,7 +16,7 @@ tasks:
       mergeInputs: "append"
 
   lint:
-    args: ['--config', '.markdownlint.yaml']
+    args: ["--config", ".markdownlint.yaml"]
     inputs:
       - ".agent/**/*.md"
       - ".claude/**/*.md"

--- a/moon.yml
+++ b/moon.yml
@@ -16,9 +16,11 @@ tasks:
       mergeInputs: "append"
 
   lint:
+    args: ['--config', '.markdownlint.yaml']
     inputs:
       - ".agent/**/*.md"
       - ".claude/**/*.md"
       - "*.md"
     options:
+      mergeArgs: "prepend"
       mergeInputs: "append"

--- a/moon.yml
+++ b/moon.yml
@@ -3,4 +3,22 @@ $schema: ".moon/cache/schemas/project.json"
 project:
   description: "Repository root"
 
-tasks: {}
+tasks:
+  format-check:
+    inputs:
+      - ".agent/**"
+      - ".claude/**"
+      - "*"
+      - ".*"
+      - "!.git/**"
+      - "!.moon/**"
+    options:
+      mergeInputs: "append"
+
+  lint:
+    inputs:
+      - ".agent/**/*.md"
+      - ".claude/**/*.md"
+      - "*.md"
+    options:
+      mergeInputs: "append"


### PR DESCRIPTION
## Summary
- Fixed cache invalidation issues when `.agent` or `.claude` directories are modified
- Removed unnecessary `runFromWorkspaceRoot` options (Moon handles this automatically)

## Changes
1. Added task definitions to `moon.yml` for the `tabler` project
   - Added `.agent/**` and `.claude/**` as inputs for `format-check` and `lint` tasks
   - Used `mergeInputs: "append"` to extend inherited global task inputs

2. Removed `runFromWorkspaceRoot` options from `.moon/tasks.yml`
   - Moon automatically runs commands from appropriate locations based on config file locations

## Test plan
- [x] Verified cache invalidates after `touch .agent/README.md` and running `moon run :check`
- [x] Verified cache invalidates after `touch .claude/agents/test.md` and running `moon run :check`
- [x] Confirmed `docs` project tasks work correctly
- [x] Confirmed root-level checks work as expected